### PR TITLE
Add overcommit configuration file

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,23 @@
+---
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+PreCommit:
+  YamlLint:
+    enabled: true
+  TrailingWhitespace:
+    enabled: true


### PR DESCRIPTION
This adds a .overcommit.yml file which configures git hooks easily.

Currently there is only a pre-commit hook to link the yaml files
which make up the majority of the content of the repo.

Close #10 

Signed-off-by: Bruce Becker <bruce.becker@uefa.ch>