### PR TITLE
Adding tests for all meetings, documentation in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__
 vendor
 _site
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -17,7 +17,61 @@ This is a list of all the meeting series we know about in:
 
 Each meeting series is represented in a data file under [_data](_data). To
 add another file, simply add it to this folder in the same format, and it
-will render on the site.
+will render on the site. 
+
+### Required Fields
+
+Specifically, the following fields are required:
+
+ - **name**: the name of the meeting
+ - **link** a url to learn about it, must begin with http*
+ - **next**: should be EITHER a string "TBA" or a single entry with:
+    - date-from: the starting date in the format YYYY-MM-DD
+    - date-to: the ending date, in the format YYYY-MM-DD
+    - link: a link to the site for the specific event, or the same link for the global event
+    - location: the location the event will take place
+
+A minimum example might look like this:
+
+```yaml
+name: FORCE11
+link: https://www.force11.org
+next:
+  date-from: 2019-10-16
+  date-to: 2019-10-17
+  link: https://www.force11.org/meetings/force2019
+  location: Edinburgh, Scotland
+```
+
+An example with an event not yet scheduled might look like this:
+
+```yaml
+name: FORCE11
+link: https://www.force11.org
+next: TBA
+```
+
+### Optional Fields
+
+If the event has had previous occurences, you should define these with a list
+of `previous`. Note the extra dash to indicate that we have a list and not a single
+entry:
+
+```
+name: FORCE11
+link: https://www.force11.org
+previous:
+  - date-from: 2019-10-16
+    date-to: 2019-10-17
+    link: https://www.force11.org/meetings/force2019
+    location: Edinburgh, Scotland
+  - date-from: 2018-10-16
+    date-to: 2018-10-17
+    link: https://www.force11.org/meetings/force2018
+    location: Edinburgh, Scotland
+```
+
+You should generally use 2 spaces as a convention for files.
 
 ## Contributing
 

--- a/_data/CIUK.yml
+++ b/_data/CIUK.yml
@@ -1,7 +1,7 @@
 name: Computing Insight UK
 link: https://www.scd.stfc.ac.uk/Pages/CIUK2019.aspx
 next:
-   date-from: 2019-12-05
-   date-to: 2019-12-06
-   link: https://www.scd.stfc.ac.uk/Pages/CIUK2019.aspx
-   location: Manchester, UK
+  date-from: 2019-12-05
+  date-to: 2019-12-06
+  link: https://www.scd.stfc.ac.uk/Pages/CIUK2019.aspx
+  location: Manchester, UK

--- a/_data/IEEE-HPEC.yml
+++ b/_data/IEEE-HPEC.yml
@@ -2,7 +2,8 @@ name: IEEE HPEC
 long-name: "IEEE High Performance Extreme Computing Conference"
 location: USA
 link: http://www.ieee-hpec.org/
-previous:
-    - date-from: 2020-09-22
-      date-to: 2020-09-24
-      location: Waltham, MA USA
+next:
+  date-from: 2020-09-22
+  date-to: 2020-09-24
+  location: Waltham, MA USA
+  link: http://www.ieee-hpec.org/

--- a/_data/PASC.yml
+++ b/_data/PASC.yml
@@ -3,8 +3,8 @@ long-name: "The Platform for Advanced Scientific Computing (PASC) Conference"
 location: Switzerland
 link: https://www.pasc-conference.org/
 next:
-   name: PASC20
-   link: https://pasc20.pasc-conference.org/
-   date-from: 2020-06-29
-   date-to: 2020-07-01
-   location: Geneva, Switzerland
+  name: PASC20
+  link: https://pasc20.pasc-conference.org/
+  date-from: 2020-06-29
+  date-to: 2020-07-01
+  location: Geneva, Switzerland

--- a/_data/SDAprofessionals.yml
+++ b/_data/SDAprofessionals.yml
@@ -1,7 +1,7 @@
 name: Safe Data Access Professionals - Connected Health Cities
 link: https://securedatagroup.org/events/
 next:
-    location: Manchester, UK
-    date-from: 2019-12-04
-    date-to:  2019-12-04
-    link: https://securedatagroup.org/events/
+  location: Manchester, UK
+  date-from: 2019-12-04
+  date-to:  2019-12-04
+  link: https://securedatagroup.org/events/

--- a/_data/SeSA.yml
+++ b/_data/SeSA.yml
@@ -1,7 +1,7 @@
 name: Swedish e-Science Academy
 link: http://www.compile.lu.se/events/?event=swedish-e-science-academy-2019
 next:
-    location: Lund, Sweden
-    date-from: 2019-10-15
-    date-to:  2019-10-16
-    link: http://www.compile.lu.se/events/?event=swedish-e-science-academy-2019
+  location: Lund, Sweden
+  date-from: 2019-10-15
+  date-to:  2019-10-16
+  link: http://www.compile.lu.se/events/?event=swedish-e-science-academy-2019

--- a/_data/chpc_za.yml
+++ b/_data/chpc_za.yml
@@ -1,4 +1,3 @@
----
 name: CHPC National Conference.
 link: 'https://chpcconf.co.za/'
 next:

--- a/_data/cw.yml
+++ b/_data/cw.yml
@@ -1,6 +1,7 @@
 name: Collabrations Workshop
 link: https://www.software.ac.uk/cw20
 next:
-   date-from: 2020-03-31
-   date-to: 2020-04-01
-   location: Belfast, NI
+  date-from: 2020-03-31
+  date-to: 2020-04-01
+  location: Belfast, NI
+  link: https://www.software.ac.uk/cw20

--- a/_data/de-rse.yml
+++ b/_data/de-rse.yml
@@ -2,8 +2,9 @@ name: deRSE
 frequency: Annual
 location: various, Germany
 link: https://www.de-rse.org/de/index.html
+next: TBA
 previous:
-    - date-from: 2019-06-04
-      date-to: 2019-06-06
-      location: Potsdam, Germany
-      link: https://www.de-rse.org/de/conf2019/index.html
+  - date-from: 2019-06-04
+    date-to: 2019-06-06
+    location: Potsdam, Germany
+    link: https://www.de-rse.org/de/conf2019/index.html

--- a/_data/eResearchAfrica.yml
+++ b/_data/eResearchAfrica.yml
@@ -1,9 +1,8 @@
----
 name: eResearch Africa
 link: http://www.eresearch.ac.za/
-last:
-  date-from: 20190515
-  date-to: 20190518
-  link: http://www.eresearch.ac.za/archive-2019
-  location: Cape Town, South Africa
-next: []
+next: "TBA"
+previous:
+  - date-from: 2019-05-15
+    date-to: 2019-05-18
+    link: http://www.eresearch.ac.za/archive-2019
+    location: Cape Town, South Africa

--- a/_data/eScience.yml
+++ b/_data/eScience.yml
@@ -1,6 +1,4 @@
 name: eScience
 link: https://escience-conference.org
-next:
-  date: !!timestamp 2020
-  link: TBD
-  location: Osaka, Japan
+next: TBA
+# 2020 in Osaka, Japan

--- a/_data/fosdem.yml
+++ b/_data/fosdem.yml
@@ -1,7 +1,7 @@
 name: FOSDEM20
 link: https://fosdem.org/2020/
 next: 
-    date-from: 2020-02-01
-    date-to: 2020-02-02
-    link: https://fosdem.org/2020/
-    location: Brussels, Belgium
+  date-from: 2020-02-01
+  date-to: 2020-02-02
+  link: https://fosdem.org/2020/
+  location: Brussels, Belgium

--- a/_data/hacktoberfest.yml
+++ b/_data/hacktoberfest.yml
@@ -1,7 +1,7 @@
 name: Hacktoberfest
 link: https://hacktoberfest.digitalocean.com
 next:
-    location: London, UK
-    date-from: 2019-10-27
-    date-to:  2019-10-27
-    link: https://hacktoberfest.digitalocean.com
+  location: London, UK
+  date-from: 2019-10-27
+  date-to:  2019-10-27
+  link: https://hacktoberfest.digitalocean.com

--- a/_data/hpc-sig.yml
+++ b/_data/hpc-sig.yml
@@ -1,7 +1,7 @@
 name: HPC-SIG 
 link: https://hpc-sig.org.uk/
 next:
-    location: Manchester, UK
-    date-from: 2019-11-06
-    date-to: 2019-11-06
-    link: https://hpc-sig.org.uk/
+  location: Manchester, UK
+  date-from: 2019-11-06
+  date-to: 2019-11-06
+  link: https://hpc-sig.org.uk/

--- a/_data/mozfest.yml
+++ b/_data/mozfest.yml
@@ -1,7 +1,7 @@
 name: Mozilla Festival
 link: https://www.mozillafestival.org/en/
 next:
-    location: London, UK
-    date-from: 2019-10-21
-    date-to:  2019-10-27
-    link: https://www.mozillafestival.org/en/
+  location: London, UK
+  date-from: 2019-10-21
+  date-to:  2019-10-27
+  link: https://www.mozillafestival.org/en/

--- a/_data/nl-rse.yml
+++ b/_data/nl-rse.yml
@@ -3,6 +3,7 @@ frequency: Annual
 location: Amsterdam, Netherlands
 link: https://nl-rse.org/events/
 next:
-  date: 2019-11-20
+  date-from: 2019-11-20
+  date-to: 2019-11-20
   location: Amsterdam, Netherlands
   link: https://nl-rse.org/events/NL-RSE19.html

--- a/_data/rdam.yml
+++ b/_data/rdam.yml
@@ -1,7 +1,7 @@
 name: Research Data Alliance Meeting
 link: https://www.rd-alliance.org/plenary-meetings/future-plenaries
 next:
-    location: Melborne, Australia
-    date-from: 2020-03-18
-    date-to: 2020-03-20
-    link: https://www.rd-alliance.org/plenary-meetings/future-plenaries
+  location: Melborne, Australia
+  date-from: 2020-03-18
+  date-to: 2020-03-20
+  link: https://www.rd-alliance.org/plenary-meetings/future-plenaries

--- a/tests/test_meetings.py
+++ b/tests/test_meetings.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+# Read in each of the data files and validate the contents
+# name: International Symposium on Cluster, Cloud and Internet Computing
+# link: http://cloudbus.org/ccgrid2020/
+# next:
+#  location: Melbourne, Australia
+#  date-from: 2020-05-11
+#  date-to: 2020-05-14
+#  link: http://cloudbus.org/ccgrid2020/
+
+import pytest
+import yaml
+from datetime import date
+from glob import glob
+import os
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+def test_meetings(tmp_path):
+    """test that meetings data files are valid.
+    """
+    data_files = os.path.join(os.path.dirname(here), '_data', '*.yml')
+
+    # required fields, and cannot be empty
+    requireds = ['name', 'link', 'next']
+
+    for data_file in glob(data_files):
+
+        # Basename for easier reference
+        name = os.path.basename(data_file)
+
+        # Navigation and table of contents
+        if name in ['navigation.yml', 'toc.yml']:
+            print("Skipping non meeting or event file %s" % data_file)
+            continue    
+
+        assert os.path.exists(data_file)
+        print("Testing loading of %s" % name)
+
+        # Read in the event
+        with open(data_file, 'r') as stream:
+            event = yaml.safe_load(stream)
+
+        # Ensure required fields present
+        for required in requireds:
+            print('Looking for %s in %s' % (required, name))
+            assert required in event
+
+        for field in event.keys():
+            if field not in requireds:
+                print('Warning: %s is a custom field in %s, not used.' % (name, field))   
+
+        # Link must be url
+        assert event['link'].startswith('http')
+
+        # Next can either be defined, or TBA
+        if isinstance(event['next'], dict):
+
+            # next requires date-to, date-from, location, link
+            for field in ['date-to', 'date-from', 'link', 'location']:
+                print("Checking for next.%s in %s" % (field, name))
+                assert field in event['next']
+
+            # must be datetims
+            assert isinstance(event['next']['date-to'], date)
+            assert isinstance(event['next']['date-from'], date)
+
+        else:
+            assert event['next'] == "TBA"


### PR DESCRIPTION
This PR will add a testing file to check the contents of each data file under _data. I'm not sure if this repo has github actions so I waited on adding a workflow, but (whatever service we add) we would basically need to install pyaml, pytest, and then run:

```bash
$ pytest tests/test_meetings.py 
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /home/vanessa/Documents/Dropbox/Code/usrse/eResearch-meeting-list, inifile:
plugins: remotedata-0.3.1, openfiles-0.3.2, doctestplus-0.3.0, arraydiff-0.3
collected 1 item                                                               
```
I've also added notes in the README about expected fields and formatting so there aren't surprises. I noticed that some files have "extra" fields that are custom/specific to them, and I didn't error/fail these tests, but likely this should be addressed in some way (likely we should decide on a specific set of officially supported fields and error if extras are found).

This will close #39, and of course we will also need to have this run automated with CI (per preference of @jamespjh )

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>