### PR TITLE
Adding GitHub CI to test events and badge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches_ignore: []
+
+jobs:
+  testing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      
+      - name: Setup environment
+        run: conda env create --quiet --name eresearch --file tests/test-environment.yml
+
+      - name: Run tests
+        env:
+          CI: true
+        run: |
+          export PATH="/usr/share/miniconda/bin:$PATH"
+          source activate eresearch
+          pytest tests/test*.py -v -x

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eResearch-meeting-list
 
+[![GitHub actions status](https://github.com/jamespjh/eResearch-meeting-list/workflows/CI/badge.svg?branch=master)](https://github.com/jamespjh/eResearch-meeting-list/actions?query=branch%3Amaster+workflow%3ACI)
+
 This is a list of all the meeting series we know about in:
 
 * eInfrastructure

--- a/tests/test-environment.yml
+++ b/tests/test-environment.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python >=3.5
+  - pyaml
+  - pytest


### PR DESCRIPTION
This pull request will add GitHub CI to automate the testing of the events! I've also added a badge to the README so the green-ness can be shown proudly :)

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>