### PR TITLE
Adding test that if previous is provided, the content is a list

### DIFF
--- a/tests/test_meetings.py
+++ b/tests/test_meetings.py
@@ -47,6 +47,11 @@ def test_meetings(tmp_path):
             print('Looking for %s in %s' % (required, name))
             assert required in event
 
+        # If a previous is included, must be list
+        if "previous" in event:
+            print("Checking that previous in %s in list" % name)
+            assert isinstance(event['previous'], list)
+
         for field in event.keys():
             if field not in requireds:
                 print('Warning: %s is a custom field in %s, not used.' % (name, field))   


### PR DESCRIPTION
This pull request will validate that if a previous tag is provided for an event, it is tested to be a list. This is logical because we will build up many more previous entries for any given event, discussed in #46.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>